### PR TITLE
feat: add fancy mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # ludunjie1219.github.io
+
+Personal site for Dunjie Lu.
+
+## Fancy Mode
+
+Click the magic wand button to switch to a colorful theme.
+

--- a/index.html
+++ b/index.html
@@ -18,6 +18,9 @@
     />
   </head>
   <body>
+    <button id="fancy-toggle" aria-label="Toggle fancy mode">
+      <i class="fa-solid fa-wand-magic-sparkles"></i>
+    </button>
     <header class="container">
       <h1>Dunjie Lu</h1>
       <div class="contact">
@@ -187,5 +190,6 @@
     <footer class="container">
       <p>&copy; 2025 Dunjie Lu</p>
     </footer>
+    <script src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,4 @@
+const toggle = document.getElementById("fancy-toggle");
+toggle.addEventListener("click", () => {
+  document.body.classList.toggle("fancy");
+});

--- a/style.css
+++ b/style.css
@@ -9,6 +9,7 @@ body {
   line-height: 1.6;
   color: #222;
   background: #f9f9fb;
+  transition: background 0.5s ease, color 0.5s ease;
 }
 
 .container {
@@ -85,4 +86,41 @@ footer {
 
 .note {
   font-style: italic;
+}
+
+#fancy-toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background: #fff;
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem 0.6rem;
+  border-radius: 50%;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  color: #444;
+  font-size: 1.1rem;
+  transition: transform 0.3s ease;
+}
+
+#fancy-toggle:hover {
+  transform: rotate(20deg);
+}
+
+body.fancy {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: #f0f0f0;
+}
+
+body.fancy a {
+  color: #ffeb3b;
+}
+
+body.fancy section h2 {
+  color: #fff;
+  border-bottom-color: rgba(255, 255, 255, 0.4);
+}
+
+body.fancy footer {
+  color: #eee;
 }


### PR DESCRIPTION
## Summary
- add floating wand button to toggle fancy mode
- style fancy mode with gradient background and playful colors
- document new fancy mode feature

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897291015288323957dc7d5c374f0aa